### PR TITLE
Add support for Spotter

### DIFF
--- a/PharoDawnTheme/GLMActionBrickDawnThemer.class.st
+++ b/PharoDawnTheme/GLMActionBrickDawnThemer.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #GLMActionBrickDawnThemer,
+	#superclass : #GLMBrickDawnThemer,
+	#category : #PharoDawnTheme
+}
+
+{ #category : #'brick-scrollbar' }
+GLMActionBrickDawnThemer >> scrollbarWidth [
+
+	^ 2
+]
+
+{ #category : #'brick-scrollpane' }
+GLMActionBrickDawnThemer >> scrollpaneBackgroundColor [
+
+	^ Color transparent
+]

--- a/PharoDawnTheme/GLMBrickDawnThemer.class.st
+++ b/PharoDawnTheme/GLMBrickDawnThemer.class.st
@@ -48,6 +48,14 @@ GLMBrickDawnThemer >> scrollbarColor [
 ]
 
 { #category : #'as yet unclassified' }
+GLMBrickDawnThemer >> spotterThemer [
+
+	^ self
+		registerModule: GTSpotterWidgetDawnThemer new
+		to: GTSpotterBrickDawnThemer new
+]
+
+{ #category : #'as yet unclassified' }
 GLMBrickDawnThemer >> tabLabelThemer [
 
 	^ self

--- a/PharoDawnTheme/GLMBrickDawnThemer.class.st
+++ b/PharoDawnTheme/GLMBrickDawnThemer.class.st
@@ -1,0 +1,67 @@
+Class {
+	#name : #GLMBrickDawnThemer,
+	#superclass : #GLMBrickThemer,
+	#category : #PharoDawnTheme
+}
+
+{ #category : #'theme-actions' }
+GLMBrickDawnThemer >> actionThemer [
+
+	^ GLMActionBrickDawnThemer new
+]
+
+{ #category : #'brick-button' }
+GLMBrickDawnThemer >> buttonBackgroundColor [
+
+	^ Color veryDarkGray lighter
+]
+
+{ #category : #'brick-button' }
+GLMBrickDawnThemer >> buttonPressedColor [
+
+	^ self backgroundColor whiter
+]
+
+{ #category : #'brick-button' }
+GLMBrickDawnThemer >> buttonSelectedColor [
+
+	^ Color veryDarkGray lighter slightlyDarker
+]
+
+{ #category : #'brick-checkbox' }
+GLMBrickDawnThemer >> checkboxBorderColor [
+
+	^ Color lightGray
+]
+
+{ #category : #brick }
+GLMBrickDawnThemer >> contentBackgroundColor [
+
+	"^ Color darkGray darker"
+	^ Color fromHexString: '262720'
+]
+
+{ #category : #'brick-scrollbar' }
+GLMBrickDawnThemer >> scrollbarColor [
+
+	^ Color black alpha: 0.5
+]
+
+{ #category : #'as yet unclassified' }
+GLMBrickDawnThemer >> tabLabelThemer [
+
+	^ self
+		registerModule: GLMBrickTabLabelDawnThemer new
+]
+
+{ #category : #brick }
+GLMBrickDawnThemer >> textColor [
+
+	^ self color whiten
+]
+
+{ #category : #brick }
+GLMBrickDawnThemer >> textSecondaryColor [
+
+	^ Color white
+]

--- a/PharoDawnTheme/GLMBrickTabLabelDawnThemer.class.st
+++ b/PharoDawnTheme/GLMBrickTabLabelDawnThemer.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : #GLMBrickTabLabelDawnThemer,
+	#superclass : #GLMBrickTabLabelThemer,
+	#category : #PharoDawnTheme
+}
+
+{ #category : #'brick-tab-label' }
+GLMBrickTabLabelDawnThemer >> normalBorderStyleFor: aBrick [
+
+	^ BorderStyle simple
+			width: 1;
+			baseColor: Color transparent
+]
+
+{ #category : #'brick-tab-label' }
+GLMBrickTabLabelDawnThemer >> normalStyleFor: aBrick [
+
+	super normalStyleFor: aBrick.
+	aBrick padding: #(0 1).
+]
+
+{ #category : #'brick-tab-label' }
+GLMBrickTabLabelDawnThemer >> selectedBorderStyleFor: aBrick [
+
+	^ self normalBorderStyleFor: aBrick
+]

--- a/PharoDawnTheme/GTPlayBindingDawnThemer.class.st
+++ b/PharoDawnTheme/GTPlayBindingDawnThemer.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #GTPlayBindingDawnThemer,
+	#superclass : #GTPlayBindingThemer,
+	#category : #PharoDawnTheme
+}
+
+{ #category : #rows }
+GTPlayBindingDawnThemer >> selectedColor [
+
+	^ Color veryVeryDarkGray alpha: 0.1
+]

--- a/PharoDawnTheme/GTSpotterBrickDawnThemer.class.st
+++ b/PharoDawnTheme/GTSpotterBrickDawnThemer.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : #GTSpotterBrickDawnThemer,
+	#superclass : #GLMBrickDarkThemer,
+	#category : #PharoDawnTheme
+}
+
+{ #category : #'brick-rubric' }
+GTSpotterBrickDawnThemer >> rubricBackgroundColor [
+
+	^ self spotterThemer backgroundColor
+]
+
+{ #category : #'brick-scrollbar' }
+GTSpotterBrickDawnThemer >> scrollbarColor [
+
+	^ self spotterThemer backgroundColor darker
+]
+
+{ #category : #'brick-scrollpane' }
+GTSpotterBrickDawnThemer >> scrollpaneBackgroundColor [
+
+	^ self spotterThemer backgroundColor
+]

--- a/PharoDawnTheme/GTSpotterWidgetDawnThemer.class.st
+++ b/PharoDawnTheme/GTSpotterWidgetDawnThemer.class.st
@@ -1,0 +1,48 @@
+Class {
+	#name : #GTSpotterWidgetDawnThemer,
+	#superclass : #GTSpotterWidgetThemer,
+	#category : #PharoDawnTheme
+}
+
+{ #category : #values }
+GTSpotterWidgetDawnThemer >> backgroundColor [
+	"used as background color for all panes"
+	^ Smalltalk ui theme lightBackgroundColor slightlyLighter
+]
+
+{ #category : #values }
+GTSpotterWidgetDawnThemer >> borderColor [
+	"color that is used for border and dividers of UI parts of Spotter
+	for example divider between header and results or between preview and list"
+	^ Smalltalk ui theme borderColor
+]
+
+{ #category : #values }
+GTSpotterWidgetDawnThemer >> itemActionSelectedBackgroundColor [
+
+	^ self itemSelectedBackgroundColor slightlyDarker
+]
+
+{ #category : #values }
+GTSpotterWidgetDawnThemer >> itemIconAlphaValue [
+
+	^ 0.5
+]
+
+{ #category : #values }
+GTSpotterWidgetDawnThemer >> itemSelectedBackgroundColor [
+
+	^ self backgroundColor slightlyDarker
+]
+
+{ #category : #values }
+GTSpotterWidgetDawnThemer >> searchFieldTextColor [
+	
+	^ Color white slightlyDarker
+]
+
+{ #category : #values }
+GTSpotterWidgetDawnThemer >> titleTextColor [
+
+	^ self backgroundColor muchLighter
+]

--- a/PharoDawnTheme/PharoDawnTheme.class.st
+++ b/PharoDawnTheme/PharoDawnTheme.class.st
@@ -89,6 +89,11 @@ PharoDawnTheme >> borderColor [
 	^ Color darkGray darker darker darker
 ]
 
+{ #category : #'as yet unclassified' }
+PharoDawnTheme >> brickThemer [
+	^ GLMBrickDawnThemer new
+]
+
 { #category : #'accessing colors' }
 PharoDawnTheme >> buttonColor [
 	^ self backgroundColor lighter lighter


### PR DESCRIPTION
Spotter was still themed as Pharo Light theme. I simply copied some classes from the Dark theme, which seems to have worked nicely. That also styled the text in GT inspector tabs in white - which is more readable than the current version, IMO...